### PR TITLE
feat(case): support goal constraint updates in record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "schemars",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ surrealdb = { version = "3", features = ["kv-rocksdb"] }
 sha2 = "0.10"
 rmcp = { version = "1.2.0", features = ["client", "transport-io"] }
 uuid = { version = "1", features = ["v4"] }
+schemars = "1.2"

--- a/crates/agpod-case/Cargo.toml
+++ b/crates/agpod-case/Cargo.toml
@@ -21,6 +21,7 @@ dirs = { workspace = true }
 sha2 = { workspace = true }
 termtree = { workspace = true }
 uuid = { workspace = true }
+schemars = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/agpod-case/src/cli.rs
+++ b/crates/agpod-case/src/cli.rs
@@ -83,9 +83,13 @@ pub enum CaseCommand {
         #[arg(long)]
         summary: String,
 
-        /// Kind: note, finding, evidence, blocker
+        /// Kind of record to append
         #[arg(long, default_value = "note")]
         kind: String,
+
+        /// Goal-level constraint update payload (JSON: {"rule":"...","reason":"..."})
+        #[arg(long = "goal-constraint")]
+        goal_constraints: Vec<String>,
 
         /// Related file paths (comma-separated)
         #[arg(long)]

--- a/crates/agpod-case/src/client.rs
+++ b/crates/agpod-case/src/client.rs
@@ -277,6 +277,29 @@ impl CaseClient {
         Ok(())
     }
 
+    pub async fn update_case_goal_constraints(
+        &self,
+        case_id: &str,
+        goal_constraints: &[Constraint],
+    ) -> CaseResult<()> {
+        let now = Utc::now().to_rfc3339();
+        let constraints_json =
+            serde_json::to_string(goal_constraints).map_err(|e| CaseError::Other(e.to_string()))?;
+
+        self.query_raw(
+            "UPDATE case SET goal_constraints = $goal_constraints, updated_at = $updated_at \
+             WHERE case_id = $case_id",
+            json!({
+                "case_id": case_id,
+                "goal_constraints": constraints_json,
+                "updated_at": now,
+            }),
+        )
+        .await?;
+
+        Ok(())
+    }
+
     pub async fn update_case_direction(&self, case_id: &str, direction_seq: u32) -> CaseResult<()> {
         let now = Utc::now().to_rfc3339();
         self.query_raw(

--- a/crates/agpod-case/src/commands.rs
+++ b/crates/agpod-case/src/commands.rs
@@ -193,6 +193,7 @@ pub(crate) async fn execute_command_json(
             id,
             summary,
             kind,
+            goal_constraints,
             files,
             context,
         } => {
@@ -200,7 +201,16 @@ pub(crate) async fn execute_command_json(
                 .as_ref()
                 .map(|f| f.split(',').map(|s| s.trim().to_string()).collect())
                 .unwrap_or_default();
-            cmd_record(client, id, summary, kind, &file_list, context.as_deref()).await
+            cmd_record(
+                client,
+                id,
+                summary,
+                kind,
+                goal_constraints,
+                &file_list,
+                context.as_deref(),
+            )
+            .await
         }
         CaseCommand::Decide {
             id,
@@ -342,7 +352,7 @@ fn error_next_action(error: &CaseError) -> Option<NextAction> {
             why: "review unfinished steps, then mark them done or blocked before closing the case"
                 .to_string(),
         }),
-        CaseError::InvalidRecordKind(kind) if kind == "decision" => Some(NextAction {
+        CaseError::InvalidRecordKind { kind, .. } if kind == "decision" => Some(NextAction {
             suggested_command: "decide".to_string(),
             why: "decisions belong in `case_decide`, which also requires a reason".to_string(),
         }),
@@ -601,19 +611,52 @@ async fn cmd_record(
     case_id: &str,
     summary: &str,
     kind: &str,
+    goal_constraint_strs: &[String],
     files: &[String],
     context: Option<&str>,
 ) -> CaseResult<serde_json::Value> {
-    let case = client.get_case(case_id).await?;
+    let mut case = client.get_case(case_id).await?;
     ensure_open(&case)?;
 
     if summary.trim().is_empty() {
         return Err(CaseError::Other("summary must not be empty".to_string()));
     }
 
-    RecordKind::from_str(kind).ok_or_else(|| CaseError::InvalidRecordKind(kind.to_string()))?;
+    let record_kind = kind
+        .parse::<RecordKind>()
+        .map_err(|_| CaseError::invalid_record_kind(kind))?;
+    let goal_constraints = parse_constraints(goal_constraint_strs)?;
+
+    if record_kind == RecordKind::GoalConstraintUpdate && goal_constraints.is_empty() {
+        return Err(CaseError::GoalConstraintUpdateRequiresConstraints);
+    }
+    if record_kind != RecordKind::GoalConstraintUpdate && !goal_constraints.is_empty() {
+        return Err(CaseError::GoalConstraintsOnlyAllowedForGoalConstraintUpdate);
+    }
+
+    if record_kind == RecordKind::GoalConstraintUpdate {
+        let mut merged = case.goal_constraints.clone();
+        for constraint in goal_constraints.iter().cloned() {
+            if !merged.contains(&constraint) {
+                merged.push(constraint);
+            }
+        }
+        client
+            .update_case_goal_constraints(case_id, &merged)
+            .await?;
+        case.goal_constraints = merged;
+    }
 
     let seq = next_entry_seq(client, case_id).await?;
+    let artifacts = if record_kind == RecordKind::GoalConstraintUpdate {
+        goal_constraints
+            .iter()
+            .map(serde_json::to_string)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| CaseError::Other(e.to_string()))?
+    } else {
+        vec![]
+    };
     let entry = client
         .create_entry(
             case_id,
@@ -624,7 +667,7 @@ async fn cmd_record(
             None,
             context,
             files,
-            &[],
+            &artifacts,
         )
         .await?;
 
@@ -638,7 +681,7 @@ async fn cmd_record(
         why: "the scan step is still gathering evidence".to_string(),
     };
 
-    Ok(json!({
+    let mut result = json!({
         "ok": true,
         "event": {
             "seq": entry.seq,
@@ -651,7 +694,14 @@ async fn cmd_record(
             "current": current_step.map(|s| output::step_json(&s))
         },
         "next": output::next_json(&next)
-    }))
+    });
+
+    if record_kind == RecordKind::GoalConstraintUpdate {
+        result["event"]["goal_constraints"] = json!(goal_constraints);
+        result["case"] = output::case_json(&case);
+    }
+
+    Ok(result)
 }
 
 async fn cmd_decide(
@@ -1743,6 +1793,7 @@ mod tests {
             "sample report shows one toxic audit outlier",
             "finding",
             &[],
+            &[],
             Some("audit csv was only a sample, not the full pool"),
         )
         .await
@@ -1885,6 +1936,7 @@ mod tests {
             "captured a mention of financial coverage in notes",
             "finding",
             &[],
+            &[],
             None,
         )
         .await
@@ -2013,6 +2065,7 @@ mod tests {
             &case_id,
             "record summary",
             "finding",
+            &[],
             &[],
             Some("record context"),
         )
@@ -2150,14 +2203,185 @@ mod tests {
             .expect("case id should exist")
             .to_string();
 
-        let error = cmd_record(&client, &case_id, "decision summary", "decision", &[], None)
-            .await
-            .expect_err("decision kind should be rejected in record");
+        let error = cmd_record(
+            &client,
+            &case_id,
+            "decision summary",
+            "decision",
+            &[],
+            &[],
+            None,
+        )
+        .await
+        .expect_err("decision kind should be rejected in record");
 
-        assert!(matches!(error, CaseError::InvalidRecordKind(ref kind) if kind == "decision"));
+        assert!(matches!(
+            error,
+            CaseError::InvalidRecordKind { ref kind, .. } if kind == "decision"
+        ));
         let next = error_next_action(&error).expect("decision misuse should provide hint");
         assert_eq!(next.suggested_command, "decide");
         assert!(next.why.contains("case_decide"));
+    }
+
+    #[tokio::test]
+    async fn goal_constraint_update_record_appends_case_constraints_and_logs_payload() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let config = temp_db_config(&temp_dir);
+        let client = CaseClient::new(
+            &config,
+            RepoIdentity {
+                repo_id: "aaaaaaaaaaaaaaaa".to_string(),
+                repo_label: "github.com/example/repo-a".to_string(),
+                worktree_id: "1111111111111111".to_string(),
+                worktree_root: "/tmp/repo-a".to_string(),
+            },
+        )
+        .await
+        .expect("client should initialize");
+
+        let initial_constraints =
+            vec![r#"{"rule":"先证据后推断","reason":"避免臆断"}"#.to_string()];
+        let opened = cmd_open(
+            &client,
+            "goal",
+            "direction",
+            &initial_constraints,
+            &[],
+            None,
+            None,
+        )
+        .await
+        .expect("case should open");
+        let case_id = opened["case"]["id"]
+            .as_str()
+            .expect("case id should exist")
+            .to_string();
+
+        let added_constraints = vec![
+            r#"{"rule":"保持最小改动","reason":"控制范围"}"#.to_string(),
+            r#"{"rule":"先证据后推断","reason":"避免臆断"}"#.to_string(),
+        ];
+
+        let recorded = cmd_record(
+            &client,
+            &case_id,
+            "补充全局约束",
+            "goal_constraint_update",
+            &added_constraints,
+            &[],
+            Some("新增后续执行边界"),
+        )
+        .await
+        .expect("goal constraint update should succeed");
+
+        let current_case = client.get_case(&case_id).await.expect("case should reload");
+        assert_eq!(current_case.goal_constraints.len(), 2);
+        assert_eq!(
+            recorded["case"]["goal_constraints"]
+                .as_array()
+                .map(Vec::len),
+            Some(2)
+        );
+        assert_eq!(
+            recorded["event"]["goal_constraints"]
+                .as_array()
+                .map(Vec::len),
+            Some(2)
+        );
+
+        let shown = cmd_show(&client, Some(&case_id))
+            .await
+            .expect("show should succeed");
+        let entries = shown["entries"]
+            .as_array()
+            .expect("show should include entries");
+        assert_eq!(entries[0]["kind"].as_str(), Some("goal_constraint_update"));
+        assert_eq!(entries[0]["artifacts"].as_array().map(Vec::len), Some(2));
+    }
+
+    #[tokio::test]
+    async fn goal_constraint_update_requires_goal_constraint_payload() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let config = temp_db_config(&temp_dir);
+        let client = CaseClient::new(
+            &config,
+            RepoIdentity {
+                repo_id: "aaaaaaaaaaaaaaaa".to_string(),
+                repo_label: "github.com/example/repo-a".to_string(),
+                worktree_id: "1111111111111111".to_string(),
+                worktree_root: "/tmp/repo-a".to_string(),
+            },
+        )
+        .await
+        .expect("client should initialize");
+
+        let opened = cmd_open(&client, "goal", "direction", &[], &[], None, None)
+            .await
+            .expect("case should open");
+        let case_id = opened["case"]["id"]
+            .as_str()
+            .expect("case id should exist")
+            .to_string();
+
+        let error = cmd_record(
+            &client,
+            &case_id,
+            "补充全局约束",
+            "goal_constraint_update",
+            &[],
+            &[],
+            None,
+        )
+        .await
+        .expect_err("missing goal_constraint payload should fail");
+
+        assert!(matches!(
+            error,
+            CaseError::GoalConstraintUpdateRequiresConstraints
+        ));
+    }
+
+    #[tokio::test]
+    async fn regular_record_rejects_goal_constraint_payload() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let config = temp_db_config(&temp_dir);
+        let client = CaseClient::new(
+            &config,
+            RepoIdentity {
+                repo_id: "aaaaaaaaaaaaaaaa".to_string(),
+                repo_label: "github.com/example/repo-a".to_string(),
+                worktree_id: "1111111111111111".to_string(),
+                worktree_root: "/tmp/repo-a".to_string(),
+            },
+        )
+        .await
+        .expect("client should initialize");
+
+        let opened = cmd_open(&client, "goal", "direction", &[], &[], None, None)
+            .await
+            .expect("case should open");
+        let case_id = opened["case"]["id"]
+            .as_str()
+            .expect("case id should exist")
+            .to_string();
+
+        let error = cmd_record(
+            &client,
+            &case_id,
+            "普通记录",
+            "finding",
+            &[r#"{"rule":"保持最小改动"}"#.to_string()],
+            &[],
+            None,
+        )
+        .await
+        .expect_err("non-goal-constraint record should reject payload");
+
+        assert!(matches!(
+            error,
+            CaseError::GoalConstraintsOnlyAllowedForGoalConstraintUpdate
+        ));
     }
 
     #[tokio::test]

--- a/crates/agpod-case/src/error.rs
+++ b/crates/agpod-case/src/error.rs
@@ -1,3 +1,4 @@
+use crate::types::RecordKind;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -56,9 +57,15 @@ pub enum CaseError {
     UnfinishedSteps,
 
     #[error(
-        "invalid record kind: {0}; use one of note, finding, evidence, blocker, or call `case_decide` for decisions"
+        "invalid record kind: {kind}; use one of {allowed}, or call `case_decide` for decisions"
     )]
-    InvalidRecordKind(String),
+    InvalidRecordKind { kind: String, allowed: String },
+
+    #[error("record kind `goal_constraint_update` requires at least one `goal_constraint`")]
+    GoalConstraintUpdateRequiresConstraints,
+
+    #[error("`goal_constraint` is only allowed when record kind is `goal_constraint_update`")]
+    GoalConstraintsOnlyAllowedForGoalConstraintUpdate,
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -71,3 +78,12 @@ pub enum CaseError {
 }
 
 pub type CaseResult<T> = Result<T, CaseError>;
+
+impl CaseError {
+    pub fn invalid_record_kind(kind: impl Into<String>) -> Self {
+        Self::InvalidRecordKind {
+            kind: kind.into(),
+            allowed: RecordKind::allowed_values_display(),
+        }
+    }
+}

--- a/crates/agpod-case/src/lib.rs
+++ b/crates/agpod-case/src/lib.rs
@@ -13,6 +13,7 @@ mod types;
 pub use cli::{CaseArgs, CaseCommand, CaseStatusArg, GoalDriftFlag, StepCommand};
 pub use config::{CaseAccessMode, CaseConfig, CaseOverrides, DbConfig, DEFAULT_CASE_SERVER_ADDR};
 pub use server::CaseServer;
+pub use types::RecordKind;
 
 use anyhow::Result;
 use serde_json::Value;

--- a/crates/agpod-case/src/types.rs
+++ b/crates/agpod-case/src/types.rs
@@ -2,10 +2,12 @@
 //!
 //! Keywords: case model, direction, step, entry, constraint
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
 
 /// A constraint rule with its rationale.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Constraint {
     pub rule: String,
     pub reason: Option<String>,
@@ -111,33 +113,65 @@ impl std::fmt::Display for EntryType {
 }
 
 /// Record kind (sub-type of EntryType::Record).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum RecordKind {
     Note,
     Finding,
     Evidence,
     Blocker,
+    GoalConstraintUpdate,
 }
 
 impl RecordKind {
+    const ALL: [Self; 5] = [
+        Self::Note,
+        Self::Finding,
+        Self::Evidence,
+        Self::Blocker,
+        Self::GoalConstraintUpdate,
+    ];
+
     #[allow(dead_code)]
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Note => "note",
             Self::Finding => "finding",
             Self::Evidence => "evidence",
             Self::Blocker => "blocker",
+            Self::GoalConstraintUpdate => "goal_constraint_update",
         }
     }
 
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn allowed_values() -> &'static [&'static str] {
+        static VALUES: OnceLock<Vec<&'static str>> = OnceLock::new();
+        VALUES.get_or_init(|| Self::ALL.iter().map(Self::as_str).collect())
+    }
+
+    pub fn allowed_values_display() -> String {
+        Self::allowed_values().join(", ")
+    }
+
+    pub fn allowed_values_code_span() -> String {
+        Self::allowed_values()
+            .iter()
+            .map(|value| format!("`{value}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+impl std::str::FromStr for RecordKind {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "note" => Some(Self::Note),
-            "finding" => Some(Self::Finding),
-            "evidence" => Some(Self::Evidence),
-            "blocker" => Some(Self::Blocker),
-            _ => None,
+            "note" => Ok(Self::Note),
+            "finding" => Ok(Self::Finding),
+            "evidence" => Ok(Self::Evidence),
+            "blocker" => Ok(Self::Blocker),
+            "goal_constraint_update" => Ok(Self::GoalConstraintUpdate),
+            _ => Err(()),
         }
     }
 }

--- a/crates/agpod-mcp/src/lib.rs
+++ b/crates/agpod-mcp/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Keywords: mcp, model context protocol, case tools, schema, stdio
 
-use agpod_case::{CaseArgs, CaseCommand, CaseStatusArg, GoalDriftFlag, StepCommand};
+use agpod_case::{CaseArgs, CaseCommand, CaseStatusArg, GoalDriftFlag, RecordKind, StepCommand};
 use anyhow::Result;
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -210,7 +210,8 @@ impl AgpodMcpServer {
                 kind: req
                     .kind
                     .map(|kind| kind.as_str().to_string())
-                    .unwrap_or_else(|| "note".to_string()),
+                    .unwrap_or_else(|| RecordKind::Note.as_str().to_string()),
+                goal_constraints: encode_constraints(req.goal_constraints),
                 files: req.files.map(|files| files.join(",")),
                 context: req.context,
             },
@@ -719,6 +720,25 @@ fn copy_case_steps_add_passthrough_fields(
     }
 }
 
+fn deserialize_optional_record_kind<'de, D>(deserializer: D) -> Result<Option<RecordKind>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Option::<String>::deserialize(deserializer)?;
+    match raw.as_deref() {
+        None => Ok(None),
+        Some("decision") => Err(D::Error::custom(
+            "invalid record kind `decision`; use `case_decide` because decisions require a reason",
+        )),
+        Some(value) => value.parse::<RecordKind>().map(Some).map_err(|_| {
+            D::Error::custom(format!(
+                "invalid record kind `{value}`; expected one of {}",
+                RecordKind::allowed_values_code_span()
+            ))
+        }),
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct CaseCurrentRequest {}
 
@@ -746,53 +766,16 @@ pub struct CaseRecordRequest {
     pub id: String,
     /// Fact summary.
     pub summary: String,
-    /// note, finding, evidence, or blocker.
-    pub kind: Option<RecordKindArg>,
+    /// Kind of record to append.
+    #[serde(default, deserialize_with = "deserialize_optional_record_kind")]
+    pub kind: Option<RecordKind>,
+    /// Goal constraint payloads. Only valid when `kind` is `goal_constraint_update`.
+    #[serde(default)]
+    pub goal_constraints: Vec<ConstraintInput>,
     /// Related file paths.
     pub files: Option<Vec<String>>,
     /// Extra context.
     pub context: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, schemars::JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum RecordKindArg {
-    Note,
-    Finding,
-    Evidence,
-    Blocker,
-}
-
-impl RecordKindArg {
-    fn as_str(&self) -> &'static str {
-        match self {
-            Self::Note => "note",
-            Self::Finding => "finding",
-            Self::Evidence => "evidence",
-            Self::Blocker => "blocker",
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for RecordKindArg {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let raw = String::deserialize(deserializer)?;
-        match raw.as_str() {
-            "note" => Ok(Self::Note),
-            "finding" => Ok(Self::Finding),
-            "evidence" => Ok(Self::Evidence),
-            "blocker" => Ok(Self::Blocker),
-            "decision" => Err(D::Error::custom(
-                "invalid record kind `decision`; use `case_decide` because decisions require a reason",
-            )),
-            _ => Err(D::Error::custom(format!(
-                "invalid record kind `{raw}`; expected one of `note`, `finding`, `evidence`, `blocker`"
-            ))),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -1081,6 +1064,7 @@ mod tests {
         assert!(record_schema_text.contains("\"finding\""));
         assert!(record_schema_text.contains("\"evidence\""));
         assert!(record_schema_text.contains("\"blocker\""));
+        assert!(record_schema_text.contains("\"goal_constraint_update\""));
         assert!(!record_schema_text.contains("\"decision\""));
     }
 
@@ -1094,6 +1078,25 @@ mod tests {
         .expect_err("decision should not deserialize as record kind");
 
         assert!(error.to_string().contains("use `case_decide`"));
+    }
+
+    #[test]
+    fn record_kind_deserialize_accepts_goal_constraint_update() {
+        let request = serde_json::from_value::<CaseRecordRequest>(serde_json::json!({
+            "id": "C-1",
+            "summary": "update constraints",
+            "kind": "goal_constraint_update",
+            "goal_constraints": [
+                {"rule": "先证据后推断", "reason": "避免臆断"}
+            ]
+        }))
+        .expect("goal_constraint_update should deserialize");
+
+        assert!(matches!(
+            request.kind,
+            Some(RecordKind::GoalConstraintUpdate)
+        ));
+        assert_eq!(request.goal_constraints.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- let `case_record` accept `goal_constraint_update` plus `goal_constraints` payloads
- append those constraints into case-level `goal_constraints` while keeping an audit entry
- derive allowed record-kind strings from `agpod_case::RecordKind` so CLI/MCP copy stays in sync

## Testing
- cargo test -p agpod-case record_ -- --nocapture
- cargo test -p agpod-case goal_constraint_update -- --nocapture
- cargo test -p agpod-mcp record_kind_deserialize -- --nocapture
- cargo clippy -p agpod-case -p agpod-mcp -- -D warnings