### PR TITLE
fix(case): handle legacy data recovery for interrupted redirects

### DIFF
--- a/crates/agpod-case/src/client.rs
+++ b/crates/agpod-case/src/client.rs
@@ -353,7 +353,9 @@ impl CaseClient {
         let now = Utc::now().to_rfc3339();
         self.query_raw(
             "UPDATE case SET current_direction_seq = $seq, current_step_id = '', \
-             updated_at = $updated_at WHERE case_id = $case_id",
+             updated_at = $updated_at, \
+             close_confirm_token = '', close_confirm_action = '', close_confirm_summary = '' \
+             WHERE case_id = $case_id",
             json!({
                 "case_id": case_id,
                 "seq": direction_seq,
@@ -450,6 +452,16 @@ impl CaseClient {
             .first()
             .and_then(parse_single_direction)
             .ok_or_else(|| CaseError::Other("no direction found".to_string()))
+    }
+
+    pub async fn find_direction(&self, case_id: &str, seq: u32) -> CaseResult<Option<Direction>> {
+        let results = self
+            .query_raw(
+                "SELECT * FROM direction WHERE case_id = $case_id AND seq = $seq LIMIT 1",
+                json!({ "case_id": case_id, "seq": seq }),
+            )
+            .await?;
+        Ok(results.first().and_then(parse_single_direction))
     }
 
     // ── Step operations ──
@@ -1197,5 +1209,52 @@ mod tests {
         assert!(Arc::ptr_eq(&first_lock, &second_lock));
         drop(first_lock);
         drop(second_lock);
+    }
+
+    #[tokio::test]
+    async fn update_case_direction_clears_close_confirmation_fields() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let config = temp_db_config(&temp_dir);
+        let client = CaseClient::new(
+            &config,
+            RepoIdentity {
+                repo_id: "aaaaaaaaaaaaaaaa".to_string(),
+                repo_label: "github.com/example/repo-a".to_string(),
+                worktree_id: "1111111111111111".to_string(),
+                worktree_root: "/tmp/repo-a".to_string(),
+            },
+        )
+        .await
+        .expect("client should initialize");
+
+        client
+            .create_case("C-legacy", "goal", &[])
+            .await
+            .expect("case should be created");
+
+        client
+            .set_close_confirmation("C-legacy", "close", "summary", "token")
+            .await
+            .expect("close confirmation should be set");
+
+        client
+            .update_case_direction("C-legacy", 2)
+            .await
+            .expect("case update should clear close confirmation fields");
+
+        let raw = client
+            .query_raw(
+                "SELECT close_confirm_token, close_confirm_action, close_confirm_summary, current_direction_seq \
+                 FROM case WHERE case_id = $case_id LIMIT 1",
+                json!({ "case_id": "C-legacy" }),
+            )
+            .await
+            .expect("query should succeed");
+        let case = raw.first().expect("legacy case should exist");
+
+        assert_eq!(case["close_confirm_token"].as_str(), Some(""));
+        assert_eq!(case["close_confirm_action"].as_str(), Some(""));
+        assert_eq!(case["close_confirm_summary"].as_str(), Some(""));
+        assert_eq!(case["current_direction_seq"].as_u64(), Some(2));
     }
 }

--- a/crates/agpod-case/src/commands.rs
+++ b/crates/agpod-case/src/commands.rs
@@ -954,6 +954,45 @@ async fn cmd_redirect(
         .await?;
 
     let new_seq = case.current_direction_seq + 1;
+    if let Some(existing_dir) = client.find_direction(case_id, new_seq).await? {
+        // Recover the common half-written redirect case: the next direction already exists,
+        // but the case pointer never advanced because the final UPDATE failed.
+        if existing_dir.summary == direction
+            && existing_dir.constraints == constraints
+            && existing_dir.success_condition == success_condition
+            && existing_dir.abort_condition == abort_condition
+            && existing_dir.reason.as_deref() == Some(reason)
+            && existing_dir.context.as_deref() == Some(context)
+        {
+            client.update_case_direction(case_id, new_seq).await?;
+
+            let next = NextAction {
+                suggested_command: "step add".to_string(),
+                why: "the recovered direction needs a fresh execution queue".to_string(),
+            };
+
+            return Ok(json!({
+                "ok": true,
+                "event": {
+                    "seq": serde_json::Value::Null,
+                    "entry_type": "redirect_recovered",
+                    "summary": "recovered previously written redirect direction",
+                    "from_direction": prev_dir.summary,
+                    "to_direction": existing_dir.summary,
+                    "reason": reason,
+                    "context": context
+                },
+                "direction": output::direction_json(&existing_dir),
+                "steps": output::steps_json(&[]),
+                "context": output::context_json(case_id, new_seq),
+                "next": output::next_json(&next)
+            }));
+        }
+
+        return Err(CaseError::Other(format!(
+            "direction seq {new_seq} already exists for case {case_id}; likely a partial redirect residue with different content"
+        )));
+    }
 
     // Create redirect entry
     let entry_seq = next_entry_seq(client, case_id).await?;
@@ -2799,5 +2838,184 @@ mod tests {
         .expect_err("goal drift should force a new case instead of redirect");
 
         assert!(matches!(error, CaseError::GoalDriftRequiresNewCase));
+    }
+
+    #[tokio::test]
+    async fn redirect_recovers_when_next_direction_already_exists() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let config = temp_db_config(&temp_dir);
+        let client = CaseClient::new(
+            &config,
+            RepoIdentity {
+                repo_id: "aaaaaaaaaaaaaaaa".to_string(),
+                repo_label: "github.com/example/repo-a".to_string(),
+                worktree_id: "1111111111111111".to_string(),
+                worktree_root: "/tmp/repo-a".to_string(),
+            },
+        )
+        .await
+        .expect("client should initialize");
+
+        let opened = cmd_open_new(&client, "goal", "direction", &[], &[], None, None)
+            .await
+            .expect("case should open");
+        let case_id = opened["case"]["id"]
+            .as_str()
+            .expect("case id should exist")
+            .to_string();
+
+        client
+            .create_direction(
+                &case_id,
+                2,
+                "new direction",
+                &[],
+                "success",
+                "abort",
+                Some("topic changed"),
+                Some("work drifted"),
+            )
+            .await
+            .expect("residual direction should be inserted");
+
+        let redirected = cmd_redirect(
+            &client,
+            &case_id,
+            "new direction",
+            "topic changed",
+            "work drifted",
+            GoalDriftFlag::No,
+            &[],
+            "success",
+            "abort",
+        )
+        .await
+        .expect("redirect should recover from matching residual direction");
+
+        assert_eq!(
+            redirected["event"]["entry_type"].as_str(),
+            Some("redirect_recovered")
+        );
+        assert_eq!(
+            redirected["context"]["current_direction_seq"].as_u64(),
+            Some(2)
+        );
+        let case = client
+            .get_case(&case_id)
+            .await
+            .expect("case should still exist");
+        assert_eq!(case.current_direction_seq, 2);
+    }
+
+    #[tokio::test]
+    async fn redirect_rejects_conflicting_residual_direction() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let config = temp_db_config(&temp_dir);
+        let client = CaseClient::new(
+            &config,
+            RepoIdentity {
+                repo_id: "aaaaaaaaaaaaaaaa".to_string(),
+                repo_label: "github.com/example/repo-a".to_string(),
+                worktree_id: "1111111111111111".to_string(),
+                worktree_root: "/tmp/repo-a".to_string(),
+            },
+        )
+        .await
+        .expect("client should initialize");
+
+        let opened = cmd_open_new(&client, "goal", "direction", &[], &[], None, None)
+            .await
+            .expect("case should open");
+        let case_id = opened["case"]["id"]
+            .as_str()
+            .expect("case id should exist")
+            .to_string();
+
+        client
+            .create_direction(
+                &case_id,
+                2,
+                "stale direction",
+                &[],
+                "success",
+                "abort",
+                Some("old reason"),
+                Some("old context"),
+            )
+            .await
+            .expect("conflicting residual direction should be inserted");
+
+        let error = cmd_redirect(
+            &client,
+            &case_id,
+            "new direction",
+            "topic changed",
+            "work drifted",
+            GoalDriftFlag::No,
+            &[],
+            "success",
+            "abort",
+        )
+        .await
+        .expect_err("conflicting residual direction should be rejected");
+
+        let message = error.to_string();
+        assert!(message.contains("partial redirect residue"));
+    }
+
+    #[tokio::test]
+    async fn redirect_rejects_residual_direction_with_different_reason_or_context() {
+        let temp_dir = TempDir::new().expect("temporary directory should be created");
+        let config = temp_db_config(&temp_dir);
+        let client = CaseClient::new(
+            &config,
+            RepoIdentity {
+                repo_id: "aaaaaaaaaaaaaaaa".to_string(),
+                repo_label: "github.com/example/repo-a".to_string(),
+                worktree_id: "1111111111111111".to_string(),
+                worktree_root: "/tmp/repo-a".to_string(),
+            },
+        )
+        .await
+        .expect("client should initialize");
+
+        let opened = cmd_open_new(&client, "goal", "direction", &[], &[], None, None)
+            .await
+            .expect("case should open");
+        let case_id = opened["case"]["id"]
+            .as_str()
+            .expect("case id should exist")
+            .to_string();
+
+        client
+            .create_direction(
+                &case_id,
+                2,
+                "new direction",
+                &[],
+                "success",
+                "abort",
+                Some("stale reason"),
+                Some("work drifted"),
+            )
+            .await
+            .expect("residual direction should be inserted");
+
+        let error = cmd_redirect(
+            &client,
+            &case_id,
+            "new direction",
+            "topic changed",
+            "work drifted",
+            GoalDriftFlag::No,
+            &[],
+            "success",
+            "abort",
+        )
+        .await
+        .expect_err("different reason should block residual recovery");
+
+        let message = error.to_string();
+        assert!(message.contains("partial redirect residue"));
     }
 }

--- a/crates/agpod-case/src/output.rs
+++ b/crates/agpod-case/src/output.rs
@@ -472,19 +472,22 @@ fn render_entries(entries: &[Value]) {
 }
 
 fn render_event(event: &Value) {
-    let seq = event.get("seq").and_then(|v| v.as_u64()).unwrap_or(0);
+    let seq = event.get("seq").and_then(|v| v.as_u64());
     let entry_type = event
         .get("entry_type")
         .and_then(|v| v.as_str())
         .unwrap_or("?");
     let summary = event.get("summary").and_then(|v| v.as_str());
 
-    println!("\n  event #{seq} ({entry_type})");
+    match seq {
+        Some(seq) => println!("\n  event #{seq} ({entry_type})"),
+        None => println!("\n  event ({entry_type})"),
+    }
     if let Some(s) = summary {
         println!("    {s}");
     }
 
-    if entry_type == "redirect" {
+    if matches!(entry_type, "redirect" | "redirect_recovered") {
         if let Some(from) = event.get("from_direction").and_then(|v| v.as_str()) {
             println!("\n  from:  {from}");
         }


### PR DESCRIPTION
Add recovery logic for half-written redirect operations where direction exists but case pointer wasn't updated. Clear close confirmation fields when updating case direction to prevent stale state. Add find_direction query method and comprehensive tests.

Review notes:

- The recovery logic compares all direction fields for exact match, but floating-point or timestamp comparisons could be problematic if serialization differs 😢
- Missing error handling if the recovery UPDATE fails - operation would silently continue without informing the user
- Consider adding logging/metrics for recovery attempts to track how often this legacy state occurs
